### PR TITLE
Fix no such file or directory error

### DIFF
--- a/dnm.sh
+++ b/dnm.sh
@@ -58,7 +58,12 @@ function extract_sdk() {
 }
 
 function download_sdk() {
-    mv "$sdk_fileame" "${sdk_fileame}.old"
+    if [ -f "$sdk_fileame" ]
+    then
+        echo "Backing up old sdk to ${sdk_fileame}.old"
+        mv "$sdk_fileame" "${sdk_fileame}.old"
+    fi
+    
     echo "Downloading ${sdk_fileame} ${bold}(${latest_version})${normal} to ${bold}${download_dir}${normal}..."
     if [[ -n $TRAVIS ]]; then
         wget -q -m --no-directories $sdk_download_url


### PR DESCRIPTION
Fixes the following error when running on a system without this script run prior
mv: cannot stat 'dotnet-sdk-latest-linux-x64.tar.gz': No such file or directory